### PR TITLE
Bugfix thumbnails

### DIFF
--- a/src/components/thumbs/thumbs.js
+++ b/src/components/thumbs/thumbs.js
@@ -88,7 +88,7 @@ const Thumbs = {
       } else {
         newThumbsIndex = swiper.realIndex;
       }
-      if (thumbsSwiper.visibleSlidesIndexes.indexOf(newThumbsIndex) < 0) {
+      if (thumbsSwiper.visibleSlidesIndexes && thumbsSwiper.visibleSlidesIndexes.indexOf(newThumbsIndex) < 0) {
         if (thumbsSwiper.params.centeredSlides) {
           if (newThumbsIndex > currentThumbsIndex) {
             newThumbsIndex = newThumbsIndex - Math.floor(slidesPerView / 2) + 1;


### PR DESCRIPTION
Fixes the bug 'Cannot read property `indexOf` of undefined' described in step 1 of [#2990](https://github.com/nolimits4web/swiper/issues/2990) that sometimes occurs on use of thumbnails
